### PR TITLE
Use env vars for path configuration

### DIFF
--- a/AnalyzeAndPush.py
+++ b/AnalyzeAndPush.py
@@ -29,10 +29,19 @@ summarizer = pipeline(
 )
 
 # ------------------------------------------
-# 4) Rutas de carpetas (ajusta a tu OneDrive)
+# 4) Rutas de carpetas
 # ------------------------------------------
-TRANSCRIPTS_FOLDER = r"E:\OneDrive - EMERALD DIGITAL SC\MeetAI"
-DONE_FOLDER = os.path.join(TRANSCRIPTS_FOLDER, "transcripts_done")
+# Las carpetas de entrada y salida se obtienen de variables de entorno para
+# evitar rutas absolutas dependientes de la máquina local.  MEETAI_INPUT
+# apunta a la carpeta con los ficheros .txt que se enviarán a Notion y
+# MEETAI_OUTPUT indica dónde se moverán una vez procesados.  Si MEETAI_OUTPUT
+# no se define, se usará la misma ruta de entrada.
+TRANSCRIPTS_FOLDER = os.getenv("MEETAI_INPUT")
+if TRANSCRIPTS_FOLDER is None:
+    raise RuntimeError("Debes definir la variable de entorno MEETAI_INPUT")
+
+output_base = os.getenv("MEETAI_OUTPUT", TRANSCRIPTS_FOLDER)
+DONE_FOLDER = os.path.join(output_base, "transcripts_done")
 os.makedirs(DONE_FOLDER, exist_ok=True)
 
 # ------------------------------------------

--- a/Transcript.py
+++ b/Transcript.py
@@ -2,19 +2,28 @@ import os
 import shutil
 import whisper
 
-# —————————— AJUSTA ESTAS RUTAS —————————— #
-# Carpeta sincronizada con OneDrive (entrada de audios)
-INPUT_FOLDER  = r"E:\OneDrive - EMERALD DIGITAL SC\AudioParaTranscribir"
-
-# Carpeta donde se guardarán los .txt
-OUTPUT_FOLDER = r"E:\OneDrive - EMERALD DIGITAL SC\MeetAI"
+# -------------------------------------------------------
+# Carpeta de entrada y salida definidas por variables de
+# entorno para evitar rutas absolutas.  MEETAI_INPUT es
+# la carpeta con los audios a transcribir y MEETAI_OUTPUT
+# la carpeta donde se guardarán los .txt resultantes.
+# -------------------------------------------------------
+INPUT_FOLDER = os.getenv("MEETAI_INPUT")
+OUTPUT_FOLDER = os.getenv("MEETAI_OUTPUT")
+if INPUT_FOLDER is None or OUTPUT_FOLDER is None:
+    raise RuntimeError(
+        "Debes definir las variables MEETAI_INPUT y MEETAI_OUTPUT"
+    )
 
 # Nombre de la subcarpeta donde moveremos los audios ya procesados
 DONE_SUBFOLDER = "transcript_done"
 # ————————————————————————————————————————————— #
 
-# Si tu ffmpeg no está en PATH global, descomenta esta línea:
-os.environ["PATH"] += os.pathsep + r"F:\ffmpeg"
+# Si ffmpeg no está en PATH global, se puede indicar mediante la variable de
+# entorno FFMPEG_PATH.  Si existe, se añade al PATH del proceso.
+ffmpeg_path = os.getenv("FFMPEG_PATH")
+if ffmpeg_path:
+    os.environ["PATH"] += os.pathsep + ffmpeg_path
 
 # Cargar modelo Whisper (ajusta a "tiny" si necesitas menos VRAM)
 model = whisper.load_model("base")


### PR DESCRIPTION
## Summary
- remove hard-coded OneDrive paths
- let AnalyzeAndPush and Transcript read folders from `MEETAI_INPUT`/`MEETAI_OUTPUT`
- allow overriding ffmpeg path via `FFMPEG_PATH` env var

## Testing
- `python -m py_compile AnalyzeAndPush.py Transcript.py`

------
https://chatgpt.com/codex/tasks/task_e_684129da9cf8832f94ec7fee5d04321f